### PR TITLE
Expose backgroundColor of underlying labels

### DIFF
--- a/BetterLabel/BetterAttributedLabel.swift
+++ b/BetterLabel/BetterAttributedLabel.swift
@@ -20,7 +20,12 @@ open class BetterAttributedLabel: UIView {
     open var contentInset = UIEdgeInsets.zero {
         didSet { updateLayout() }
     }
-    
+
+    open override var backgroundColor: UIColor? {
+        get { label.backgroundColor }
+        set { label.backgroundColor = newValue }
+    }
+
     open override var forFirstBaselineLayout: UIView { label }
     
     open override var forLastBaselineLayout: UIView { label }

--- a/BetterLabel/BetterAttributedLabel.swift
+++ b/BetterLabel/BetterAttributedLabel.swift
@@ -22,8 +22,11 @@ open class BetterAttributedLabel: UIView {
     }
 
     open override var backgroundColor: UIColor? {
-        get { label.backgroundColor }
-        set { label.backgroundColor = newValue }
+        get { self.backgroundColor }
+        set {
+            self.backgroundColor = newValue
+            label.backgroundColor = newValue
+        }
     }
 
     open override var forFirstBaselineLayout: UIView { label }

--- a/BetterLabel/BetterAttributedLabel.swift
+++ b/BetterLabel/BetterAttributedLabel.swift
@@ -22,9 +22,9 @@ open class BetterAttributedLabel: UIView {
     }
 
     open override var backgroundColor: UIColor? {
-        get { self.backgroundColor }
+        get { super.backgroundColor }
         set {
-            self.backgroundColor = newValue
+            super.backgroundColor = newValue
             label.backgroundColor = newValue
         }
     }

--- a/BetterLabel/BetterLabel.swift
+++ b/BetterLabel/BetterLabel.swift
@@ -46,7 +46,12 @@ open class BetterLabel: UIView {
     open var lineSpacing: CGFloat? = nil {
         didSet { updateAttributedString() }
     }
-    
+
+    open override var backgroundColor: UIColor? {
+        get { label.backgroundColor }
+        set { label.backgroundColor = newValue }
+    }
+
     open override var forFirstBaselineLayout: UIView { label.forFirstBaselineLayout }
     open override var forLastBaselineLayout: UIView { label.forLastBaselineLayout }
     


### PR DESCRIPTION
Currently, user is not able to set the `backgroundColor` of `BetterLabel` and `BetterAttributedLabel` underlying labels. This can be a problem when optimizing UIKit performance and removing blended layers.

This MR exposes `backgroundColor` property of `BetterLabel` and `BetterAttributedLabel`, setting the `backgroundColor` of underlying labels.